### PR TITLE
Add menu link to github repo.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,6 +22,7 @@
 		        <li><a href="{{ page.url | absolute_url }}">{{ page.title }}</a></li>
 		    {% endif %}
 		{% endfor %}
+		<li><a href=https://github.com/rses-datascience>Github Repository</a></li>
 	</ul>
 	<ul class="actions vertical">
 		<li><a href="#" class="button special fit">Get Started</a></li>


### PR DESCRIPTION
We were missing a convenient link to the github repo. Added to bottom of menu.