### PR TITLE
Created Blog Post List

### DIFF
--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -1,0 +1,44 @@
+<!-- Table Layout -->
+<table id="posttable">
+    <thead>
+        <tr>
+            <th>Date</th>
+            <th>Title</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for post in site.categories.blog %}
+    {% if site.tiles-source == 'posts' %}
+        <tr href="{{ post.url  | relative_url }}" class="link">
+                <th>
+                    {{ post.date  | date: "%B %d, %Y"}}
+                </th>
+                <td>
+                    <a href="{{ post.url  | relative_url }}" class="link">{{ post.title }} </a>
+                </td>
+                <td>
+                    {{ post.description }}
+                </td>                    
+        </tr>
+    {% endif %}
+    {% endfor %}
+    </tbody>
+</table>
+
+<!-- Tile Layout -->
+<!-- <section id="one" class="tiles">
+    {% for post in site.categories.blog %}
+    {% if site.tiles-source == 'posts' %}
+        <article>
+                <span class="image">
+                        <img src="{{ post.image }}" alt="" />
+                </span>
+                <header class="major">
+                        <h3><a href="{{ post.url  | relative_url }}" class="link">{{ post.title }}</a></h3>
+                        <p>{{ post.description }}</p>
+                </header>
+        </article>
+    {% endif %}
+    {% endfor %}
+</section> -->

--- a/_posts/2017-10-30-Malcolm_talk.md
+++ b/_posts/2017-10-30-Malcolm_talk.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Fitting lines and curves to data… Its like running with scissors.
-description: Data Science news
+description: Data Seminar Write-Up
+categories: blog
 image:
 ---
 

--- a/_posts/2017-3-28-formation.md
+++ b/_posts/2017-3-28-formation.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: RSES Data Science Website running
-description: Data science news
+description: Announcement
+categories: blog
 image:
 ---
 

--- a/_posts/2017-7-7-malcolmseminar.md
+++ b/_posts/2017-7-7-malcolmseminar.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: The Story of Nothing
-description: Data Science news
+description: Data Seminar Write-Up
+categories: blog
 image:
 ---
 

--- a/_posts/2017-8-9-firstdatasurgery.md
+++ b/_posts/2017-8-9-firstdatasurgery.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Data Surgeries Are Go!
-description: Data Science News
+description: Announcement
+categories: blog
 image: 
 ---
 

--- a/_posts/2017-9-16-andrewvalentine.md
+++ b/_posts/2017-9-16-andrewvalentine.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: What is machine learning?
-description: Data Science news
+description: Data Seminar Write-Up
+categories: blog
 image:
 ---
 

--- a/_posts/2018-02-22-Resources.md
+++ b/_posts/2018-02-22-Resources.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: RSES Data and Computational Resources for Research seminar
-description: Data Science news
+description: Resources
+categories: blog
 ---
 
 The Data and Computational Resources for Research seminar took place at RSES on Thursday the 22nd of February, and was organised as part of the Data Science Research Theme. After an introduction by RSES Director Prof. Steve Eggins, Dr. Lesley Wyborn (Adjunct Fellow, ANU) gave an overview of the seminars that aimed at providing information about the computational and data resources available at RSES, and more broadly ANU, for RSES staffs and students.

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Blog Posts
+description: List of All Blog Posts
+image: 
+nav-menu: true
+---
+
+<h1>RSES Data Science Blog Posts</h1>
+<div class='tiles'>
+{% include post-list.html %}
+</div>

--- a/datasurgery.md
+++ b/datasurgery.md
@@ -17,7 +17,6 @@ nav-menu: true
 		</header>
 		<a href="http://rses.anu.edu.au/people/david-heslop">David Heslop</a>,
 		<a href="http://rses.anu.edu.au/people/oscar-branson">Oscar Branson</a>,
-		<a href="http://www.physics.mun.ca/~jmunroe/">James Munroe</a>
 		<p></p>
 		<header class="minor">
 			<h2>Schedule</h2>


### PR DESCRIPTION
List:
- Is formatted as a table (can be switched to tile, but this will get clumsy as number of posts increases).
- Appears as a link in drop-down navigation menu.

Including Items:
- All posts that have `categories: blog` in the header will be included in the list.
- The `description` header item is also displayed in the table, so make it meaningful.

Modifying list:
- Code is in _includes/site-list.html
- Index is in blog.md at top level.

Closes #48 and #17 